### PR TITLE
Enable installing with a one-liner command (with curl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,14 @@ emulator for everything to work as expected.
 Some of the configs also expect a "[nerd font](https://www.nerdfonts.com/)" to
 be configured in the terminal emulator.
 
-Apart from these, all that you should need on top of a base Manjaro install for
-the setup script to work is Git.
+Anyway, all you should need for the setup script to work is a Manjaro install.
 
 ### Installing
 
-Simply clone this repository to `~/.dotfiles` (some of the configs expect this
-path so no option to put it elsewhere for now), and then from within the cloned
-repo run:
+You can download and run the install script with this handy-dandy one-liner:
 
 ```shell
-./setup.sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/vicnett/dotfiles/refs/heads/main/setup.sh)"
 ```
 
 You will be prompted for a sudo password which will solely be used to install
@@ -54,6 +51,11 @@ exec zsh
 That, or you happened to already have your configs (visual ones at least)
 exactly the same as mine! Which would be weird but also, I mean... good on you
 for having great taste!
+
+If you're wary of running random scripts from strangers on the Internet... Well,
+it's probably a good idea to be honest... Anyway, the script is super small and
+simple so you can [take a peek](setup.sh) and/or run the commands inside
+manually.
 
 ### Updating
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,23 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
+
+DOTFILES_DIR="$HOME/.dotfiles"
+PLAYBOOK_PATH="$DOTFILES_DIR/ansible/playbook.yml"
 
 sudo pacman -S --needed --noconfirm git python-pipx
 export PATH="$PATH:~/.local/bin"
 pipx install --include-deps ansible
 
-ansible-playbook ansible/playbook.yml
+if [ ! -d $DOTFILES_DIR ]
+then
+  git clone https://github.com/vicnett/dotfiles.git $DOTFILES_DIR
+fi
+
+if [ -f $PLAYBOOK_PATH ]
+then
+  ansible-playbook $PLAYBOOK_PATH
+else
+  echo Ansible playbook not found at $PLAYBOOK_PATH
+  exit 1
+fi


### PR DESCRIPTION
What
---
Enable super lazy one-liner command to bootstrap/setup the configs on a new (Manjaro) environment.

Why
---
Partly because I'm lazy, but mostly because I always thought these were cool!

Testing
---
I built the Docker container with `--target install` so the repo files wouldn't already be copied in there, to ensure it would still work on an actually-fresh install. And it did :tada: 