### PR TITLE
Add simple docker build workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,11 @@
+name: Build Docker image
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build .

--- a/setup.sh
+++ b/setup.sh
@@ -3,10 +3,10 @@
 set -e
 
 DOTFILES_DIR="$HOME/.dotfiles"
+ANSIBLE_PATH="$HOME/.local/bin"
 PLAYBOOK_PATH="$DOTFILES_DIR/ansible/playbook.yml"
 
 sudo pacman -S --needed --noconfirm git python-pipx
-export PATH="$PATH:~/.local/bin"
 pipx install --include-deps ansible
 
 if [ ! -d $DOTFILES_DIR ]
@@ -16,7 +16,7 @@ fi
 
 if [ -f $PLAYBOOK_PATH ]
 then
-  ansible-playbook $PLAYBOOK_PATH
+  $ANSIBLE_PATH/ansible-playbook $PLAYBOOK_PATH
 else
   echo Ansible playbook not found at $PLAYBOOK_PATH
   exit 1


### PR DESCRIPTION
## What
Add a very very simple GitHub Actions workflow to build the same Dockerfile I was using to test locally, which ended up also involving adjusting the `setup.sh` script to call Ansible from its absolute path.

## Why
### The workflow
I want to use this repo as an opportunity to get familiar with CI, and I'm starting small and simple with this super tiny workflow.

### The script changes
Apparently setting the `$PATH` variable doesn't seem to work in GitHub Actions, even within a Docker container during its build process... That, or it does work but the paths are weird, I'm not sure... Either way, now that I've made the change, I think it's probably a nicer/cleaner script anyway so yay me!

## Testing
Well that's the neat part: it tested itself! The build passed!!! :tada: :heavy_check_mark: