### PR TITLE
Add vim-plug auto setup to init.vim

### DIFF
--- a/vim/init.vim
+++ b/vim/init.vim
@@ -18,6 +18,12 @@ function! s:SourceConfigFilesIn(directory)
   endfor
 endfunction
 
+let data_dir = has('nvim') ? stdpath('data') . '/site' : '~/.vim'
+if empty(glob(data_dir . '/autoload/plug.vim'))
+  silent execute '!curl -fLo '.data_dir.'/autoload/plug.vim --create-dirs  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+  autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
+endif
+
 call plug#begin('~/.vim/bundle')
 call s:SourceConfigFilesIn('~/.dotfiles/vim/rcplugins')
 call s:SourceConfigFilesIn('~/.vimrc.d/rcplugins')


### PR DESCRIPTION
## What
Add installation of [`vim-plug`](https://github.com/junegunn/vim-plug) and initial installation of plugins (`PlugInstall`) automation to `init.vim`.

## Why
I want everything (or as much as possible) to be set up and ready to go solely by running the install script.

## How
I added [a snippet provided in the `vim-plug` docs](https://github.com/junegunn/vim-plug/wiki/tips#automatic-installation) to `init.vim`. This code installs `vim-plug` and runs `PlugInstall` if it detects that `vim-plug` hasn't been installed yet.

I initially wanted to add a task to the Ansible playbook to install `vim-plug` and run `PlugInstall` but for now I like this solution because:

- It avoids adding more stuff to the playbook, which I'd like to keep a simple, single file for as long as possible
- It keeps the vim-related stuff in the `vim` directory
- At first launch of Neovim after a fresh setup, it will show the process of the plugins being installed, which I actually kind of like as opposed to a silent install