### PR TITLE
Change when Docker tests are run

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -2,6 +2,9 @@ name: Build Docker image
 
 on:
   push:
+    branches: [main]
+
+  pull_request:
 
 jobs:
   docker:


### PR DESCRIPTION
## What
This limits when Docker tests are run:
- On pushes to `main`
- On pushes to branches that have a pull request associated to them, and when said PR is opened

## Why
It's silly to run these tests on GitHub before I've opened a PR on GitHub, because until I've done so I'm obviously not looking at GitHub and I may push several times, which would mean running a bunch of workflows I won't look at...

## Testing
None; this won't really have an effect until merged so I just hope I got it right :sweat_smile: 

Edit: nah silly me, I can see that it was triggered when I opened this! All good (just have to make sure the push to `main` also triggers it tho)

Post-merge edit: yep it also worked when pushed to `main` :tada: 