### PR TITLE
Stop "prefixing" up/down arrow history search

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -34,9 +34,11 @@ ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=6'
 source /usr/bin/virtualenvwrapper.sh
 
 # Zsh history settings
+
 HISTFILE="$ZDOTDIR/.zhistory"
 HISTSIZE=10000
 SAVEHIST=$HISTSIZE
+
 # Persistent history file
 setopt append_history
 # Write to the history file upon running each command, not upon exiting shell
@@ -45,15 +47,18 @@ setopt inc_append_history
 setopt hist_ignore_all_dups
 # Don't write to history if the command starts with a space
 setopt hist_ignore_space
+
 # Search history using already-typed text with up/down arrows
 zinit load 'zsh-users/zsh-history-substring-search'
 zinit ice wait atload'_history_substring_search_config'
+# Key bindings for using zsh-history-substring-search via up/down arrows
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
-
-# Colors for matching and non-matching search terms when using up/down arrows
+# Colors for matching and non-matching search terms
 HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='fg=blue'
 HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='fg=red'
+# Only match commands that start the same as the search term
+HISTORY_SUBSTRING_SEARCH_PREFIXED='foo' # it just needs to be non-empty
 
 # Zsh completion settings (compinit needs to be run before fzf-tab is loaded)
 autoload -Uz compinit && compinit


### PR DESCRIPTION
## What

Stop matching history entries that don't start with the beginning of the search term.
For example, `ls` should match `ls -l` but not `echo ls`.

## Why

For one, I'm used to it being this way. I also think it makes more sense this way. The only exception I can think of right now is `sudo` but, again, I'm used to how it works and I don't think that's an issue... If a command needs `sudo` I'll probably have `sudo <command>` typed before trying to look at what I typed last time I used that command.

## How

The [`zsh-history-substring` documentation](https://github.com/zsh-users/zsh-history-substring-search?tab=readme-ov-file#configuration) explains that the `HISTORY_SUBSTRING_SEARCH_PREFIXED` variable is checked for being empty or non-empty, and it being non-empty results in the wanted behavior. The actual value doesn't matter so I just made it `'foo'` :smile: 