### PR TITLE
Re-enable timestamps in Zsh history file

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -39,6 +39,8 @@ HISTFILE="$ZDOTDIR/.zhistory"
 HISTSIZE=10000
 SAVEHIST=$HISTSIZE
 
+# Save timestamps in history file
+setopt extended_history
 # Persistent history file
 setopt append_history
 # Write to the history file upon running each command, not upon exiting shell


### PR DESCRIPTION
## What

Re-enable saving timestamps in `.zhistory`.

## Why

I believe this was handled by OMZ and the `HIST_STAMPS="yyyy-mm-dd"` line in `.zshrc` and I completely missed it in the refactor...

## Testing

I verified that my `.zhistory` file includes timestamps after making this change and reloading Zsh :+1: 