### PR TITLE
Make recent commands clearer with transient prompt

### DIFF
--- a/zsh/p10k.zsh
+++ b/zsh/p10k.zsh
@@ -138,7 +138,7 @@
   typeset -g POWERLEVEL9K_ICON_BEFORE_CONTENT=
 
   # Add an empty line before each prompt.
-  typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=true
+  p10k-on-pre-prompt() p10k display empty_line=print
 
   # Connect left prompt lines with these symbols. You'll probably want to use the same color
   # as POWERLEVEL9K_MULTILINE_FIRST_PROMPT_GAP_FOREGROUND below.
@@ -1811,7 +1811,7 @@
   #   - always:   Trim down prompt when accepting a command line.
   #   - same-dir: Trim down prompt when accepting a command line unless this is the first command
   #               typed after changing current working directory.
-  typeset -g POWERLEVEL9K_TRANSIENT_PROMPT=always
+  typeset -g POWERLEVEL9K_TRANSIENT_PROMPT=same-dir
 
   # Instant prompt mode.
   #


### PR DESCRIPTION
## What

- Preserves the prompt for the first command run after each directory change
- Add blank lines between each past command with transient prompt

## Why

I was having a hard time finding/distinguishing recent commands with transient prompt enabled and found [this solution](https://github.com/romkatv/powerlevel10k/issues/2163#issuecomment-1397243389) from the Powerlevel10k author.

While researching this, I also found out about the option to preserve the prompt for the first command after each directory change, which also seems like it would be a nice "anchor" when parsing recent command and output history in the terminal.