### PR TITLE
Make workflow Docker builds smarter:

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,14 +1,29 @@
-name: Build Docker image
+name: Build Docker image as test
 
 on:
+  schedule:
+    - cron: '12 17 * * FRI'
   push:
-    branches: [main]
 
-  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: docker build .
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          pull: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What

Various changes to the Docker build workflow:
- Enable cache for faster builds
- Build on push, not PR, but also:
- Cancel ongoing builds when a new one is triggered (except on main)
- Scheduled weekly builds on main

## Why

I wanted to make the builds faster and make sure they don't re-download everything every time. Hopefully enabling the GitHub Actions Cache does both.

I also wanted to run builds once a week so that I would know if/when upstream updates break my stuff. I picked Friday afternoons because it feels like the best time: if there's something broken I'd rather it turn into a weekend project :grin: 

I also didn't like only building on pushes to main and PR activity, because it meant that branch builds wouldn't start until I was done typing up the PR description (or I'd have to open the PR first and then edit to add the description).

Instead, I'm back to building on every push, except now new builds should cancel existing ones if they haven't finished yet. 

## Testing

Builds take about half as long now (from ~2min to ~1min). I'd love to get this number down even lower but I'm not sure I can. At least not now...