### PR TITLE
Give GitHub Actions Workflow Runs better names

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,5 +1,7 @@
 name: Build Docker image as test
 
+run-name: "[${{ github.ref_name }}] Docker build"
+
 on:
   schedule:
     - cron: '12 17 * * FRI'


### PR DESCRIPTION
## What

Name workflow runs `[<branch-name>] Docker build` instead of letting GitHub automatically use the latest commit message (which is the default for `push`-triggered runs)

## Why

IDK, I just prefer it this way :shrug: 