### PR TITLE
Put Zsh back in Emacs mode

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -10,6 +10,11 @@ RCFILES_DIR="$HOME/.zshrc.d"
 # Directory where we want to store zinit and plugins
 ZINIT_HOME="$XDG_DATA_HOME/zinit/zinit.git"
 
+# Don't use vi mode; force Emacs mode back on
+# Zsh automatically turns on vi mode when the values of $EDITOR and/or $VISUAL
+# contain 'vi'
+bindkey -o
+
 # Download Zinit, if it's not there yet
 if [ ! -d "$ZINIT_HOME" ]; then
    mkdir -p "$(dirname $ZINIT_HOME)"


### PR DESCRIPTION
## What

Turn off vi mode / turn on Emacs mode.

## Why

Apparently if the values of either `$EDITOR` and/or `$VISUAL` contain the string `'vi'` (even partial match), then Zsh will "helpfully" turn on vi keybindings...

I decided to give it a shot and see if I'd like it, and I do not, in fact, like it. So back to Emacs bindings we go!

This must have been handled in OMZ because I've always had both `$EDITOR` and `$VISUAL` set to `vim` or `nvim` and I also never set `bindkey -o` yet also never got stuck with vi keybindings :sweat_smile: 