### PR TITLE
Add git settings

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -28,14 +28,29 @@
       register: dotbot_output
       changed_when: '"Creating" in dotbot_output.stdout'
 
-    - name: Configure global .gitignore file
-      community.general.git_config:
-        name: core.excludesfile
-        scope: global
-        value: '{{ gitignore_path }}'
+    - name: Git configuration
+      block:
 
-    - name: Include git aliases file
-      community.general.git_config:
-        name: include.path
-        scope: global
-        value: '{{ git_aliases_path }}'
+      - name: Configure global .gitignore file
+        community.general.git_config:
+          name: core.excludesfile
+          scope: global
+          value: '{{ gitignore_path }}'
+
+      - name: Include git aliases file
+        community.general.git_config:
+          name: include.path
+          scope: global
+          value: '{{ git_aliases_path }}'
+
+      - name: Make default branch "main"
+        community.general.git_config:
+          name: init.defaultBranch
+          scope: global
+          value: main
+
+      - name: Automatically set up remote tracking branch when pushing
+        community.general.git_config:
+          name: push.autoSetupRemote
+          scope: global
+          value: true

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -4,7 +4,7 @@
 
   vars:
     base_dir: '{{ playbook_dir | dirname }}'
-    gitignore_path: '~/.gitignore'
+    gitignore_path: '{{ base_dir }}/git/gitignore'
     git_aliases_path: '{{ base_dir }}/aliases/git'
 
   tasks:

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -11,7 +11,6 @@
     ~/.config/zsh/.zshrc: zsh/zshrc
     ~/.config/zsh/.zprofile: zsh/zprofile
     ~/.config/zsh/.p10k.zsh: zsh/p10k.zsh
-    ~/.gitignore: git/gitignore
     ~/.config/nvim: vim
     ~/.byobu: byobu
 


### PR DESCRIPTION
## What

Add git settings to the Ansible Playbook to:

- set the default branch name to `main`
- turn on automatic setup of remote branch when pushing

## Why

I have these in my `.gitconfig` already and they were just missing from the repo.

## Testing

Confirmed resulting `.gitconfig` in Docker contains expected settings.