### PR TITLE
Correct invalid `bindkey -o` to `bindkey -e`

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -13,7 +13,7 @@ ZINIT_HOME="$XDG_DATA_HOME/zinit/zinit.git"
 # Don't use vi mode; force Emacs mode back on
 # Zsh automatically turns on vi mode when the values of $EDITOR and/or $VISUAL
 # contain 'vi'
-bindkey -o
+bindkey -e
 
 # Download Zinit, if it's not there yet
 if [ ! -d "$ZINIT_HOME" ]; then


### PR DESCRIPTION
## What

I fat-fingered `bindkey -e` into `bindkey -o` in #14... I know `e` and `o` are under different hands on my keyboard... Shhhhh...