### PR TITLE
Add Zsh key bindings

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -32,6 +32,10 @@ zinit light zdharma-continuum/fast-syntax-highlighting
 zinit light zsh-users/zsh-completions
 zinit light zsh-users/zsh-autosuggestions
 
+# Add key bindings
+zinit snippet OMZL::key-bindings.zsh
+bindkey '^H' backward-kill-word
+
 # Color for autosuggestions
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=6'
 


### PR DESCRIPTION
## What

Add Zsh key bindings for more pleasing command editing.

## How

Since I didn't even realize Zsh didn't have sane bindings by default, clearly I was happy with OMZ bindings so I added a snippet for their keybindings file.

Then I realized that `Ctrl + Backspace` still didn't delete words, so I added that binding individually as well.

I'm sure there will be more later...