### PR TITLE
Fix zsh completion menu not highlighting selection

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -78,6 +78,8 @@ zinit cdreplay -q
 # - try case-insensitive matching if nothing matches
 # - partially match typed words (i.e. bar<tab> would match foobar)
 zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+# Highlight selected item in the menu
+zstyle ':completion:*' menu select
 # Colored completion (different colors for dirs/files/etc)
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 # automatically find new executables in path


### PR DESCRIPTION
## What

Made it so that the Zsh tab-completion menu actually highlights the item being selected. Apparently that's not default and must have come from OMZ before...