### PR TITLE
Fix missing fd package for fzf default command

### DIFF
--- a/manjaro_packages
+++ b/manjaro_packages
@@ -1,5 +1,6 @@
 neovim
 zsh
 byobu
+fd
 fzf
 ripgrep


### PR DESCRIPTION
## What

Added `fd` to `manjaro-packages`

## Why

I have my `fzf` commands set to use `fd`, but the latter wasn't being installed so `fzf` shortcuts were issuing an error.