### PR TITLE
Fix indentation and tab/space indentation representation in Neovim

### DIFF
--- a/vim/lua/config/formatting.lua
+++ b/vim/lua/config/formatting.lua
@@ -15,8 +15,10 @@ vim.opt.textwidth = 80
 -- 1 Don't break a line after a one-letter word; break it before it if possible
 vim.opt.formatoptions = jtcroql1
 
--- 2 space indentation
+-- Default to 2 space indentation
+-- Note: vim-sleuth will dynamically adjust these based on context
 vim.opt.tabstop = 2
-vim.opt.shiftwidth = 2
+vim.opt.shiftwidth = 0
+vim.opt.softtabstop = -1
 vim.opt.shiftround = true
 vim.opt.expandtab = true

--- a/vim/lua/config/general.lua
+++ b/vim/lua/config/general.lua
@@ -6,8 +6,8 @@
 -- vim.g.python_indent.closed_paren_align_last_line = v:false
 
 vim.g.python_indent = {
-	open_paren = "shiftwidth()",
-	closed_paren_align_last_line = false,
+  open_paren = "shiftwidth()",
+  closed_paren_align_last_line = false,
 }
 
 -- Fuzzy file finding

--- a/vim/lua/config/lazy.lua
+++ b/vim/lua/config/lazy.lua
@@ -1,40 +1,40 @@
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
-	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
-	local out = vim.fn.system({
-		"git",
-		"clone",
-		"--filter=blob:none",
-		"--branch=stable",
-		lazyrepo,
-		lazypath,
-	})
-	if vim.v.shell_error ~= 0 then
-		vim.api.nvim_echo({
-			{ "Failed to clone lazy.nvim:\n", "ErrorMsg" },
-			{ out, "WarningMsg" },
-			{ "\nPress any key to exit..." },
-		}, true, {})
-		vim.fn.getchar()
-		os.exit(1)
-	end
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=stable",
+    lazyrepo,
+    lazypath,
+  })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
 end
 vim.opt.rtp:prepend(lazypath)
 
 -- Setup lazy.nvim
 require("lazy").setup({
-	spec = {
-		-- import your plugins
-		{ import = "plugins" },
-	},
-	-- colorscheme that will be used when installing plugins.
-	install = { colorscheme = { "solarized" } },
-	-- automatically check for plugin updates
-	checker = { enabled = true },
-	change_detection = {
-		-- automatically check for config file changes and reload the ui
-		enabled = true,
-		notify = false, -- don't get a notification when changes are found
-	},
+  spec = {
+    -- import your plugins
+    { import = "plugins" },
+  },
+  -- colorscheme that will be used when installing plugins.
+  install = { colorscheme = { "solarized" } },
+  -- automatically check for plugin updates
+  checker = { enabled = true },
+  change_detection = {
+    -- automatically check for config file changes and reload the ui
+    enabled = true,
+    notify = false, -- don't get a notification when changes are found
+  },
 })

--- a/vim/lua/config/visual.lua
+++ b/vim/lua/config/visual.lua
@@ -5,14 +5,77 @@
 vim.opt.colorcolumn = "+1"
 
 -- Display extra whitespace
+local vert_char = "▏"
 vim.opt.list = true
 vim.opt.listchars:append({
-	tab = "▏›",
-	leadmultispace = "▏ ",
+	tab = vert_char .. "▏›",
 	trail = "·",
 	nbsp = "·",
 	multispace = "·",
 })
+
+-- Automatically adapt leadmultispace to current indentation settings, adapted
+-- from:
+-- https://github.com/gravndal/shiftwidth_leadmultispace.nvim/blob/master/plugin/shiftwidth_leadmultispace.lua
+local char = "leadmultispace:" .. vert_char
+
+local function lms(rep)
+  return char .. string.rep(" ", rep > 0 and rep - 1 or 0)
+end
+
+local function update(old, rep)
+  return old:gsub("leadmultispace:[^,]*", lms(rep))
+end
+
+local function update_curbuf()
+  for _, w in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_get_buf(w) == vim.api.nvim_get_current_buf() then
+      vim.wo[w].listchars = update(
+        vim.wo[w].listchars,
+        vim.bo.shiftwidth > 0 and vim.bo.shiftwidth or vim.bo.tabstop
+      )
+    end
+  end
+end
+
+local group = vim.api.nvim_create_augroup("ShiftwidthLeadmultispace", {})
+
+-- Sync with 'shiftwidth'.
+vim.api.nvim_create_autocmd("OptionSet", {
+  pattern = "shiftwidth,tabstop",
+  group = group,
+  callback = function()
+    if vim.v.option_type ~= "local" then
+      vim.go.listchars = update(
+        vim.go.listchars,
+        vim.go.shiftwidth > 0 and vim.go.shiftwidth or vim.go.tabstop
+      )
+    end
+    update_curbuf()
+  end,
+})
+
+-- Update 'listchars' when displaying buffer in a window.
+vim.api.nvim_create_autocmd("BufWinEnter", {
+  group = group,
+  callback = function()
+    vim.wo.listchars = update(
+      vim.wo.listchars,
+      vim.bo.shiftwidth > 0 and vim.bo.shiftwidth or vim.bo.tabstop
+    )
+  end,
+})
+
+-- Handle cases where 'filetype' is set after BufWinEnter.
+vim.api.nvim_create_autocmd("FileType", {
+  group = group,
+  callback = function()
+    update_curbuf()
+  end,
+})
+
+-- Set global default.
+vim.opt_global.listchars:append(lms(vim.go.shiftwidth))
 
 -- Display relative line numbers, with absolute line number for current line
 vim.opt.number = true
@@ -22,22 +85,22 @@ vim.opt.relativenumber = true
 -- Automatically turn off relative line numbers when not in focus
 -- ... But also don't turn them on and off for help buffers!
 local numbertogglegroup =
-	vim.api.nvim_create_augroup("numbertoggle", { clear = true })
+  vim.api.nvim_create_augroup("numbertoggle", { clear = true })
 vim.api.nvim_create_autocmd({ "BufEnter", "FocusGained", "InsertLeave" }, {
-	callback = function()
-		if vim.bo.filetype ~= "help" then
-			vim.opt.relativenumber = true
-		end
-	end,
-	group = numbertogglegroup,
-	pattern = "*",
+  callback = function()
+    if vim.bo.filetype ~= "help" then
+      vim.opt.relativenumber = true
+    end
+  end,
+  group = numbertogglegroup,
+  pattern = "*",
 })
 vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter" }, {
-	callback = function()
-		vim.opt.relativenumber = false
-	end,
-	group = numbertogglegroup,
-	pattern = "*",
+  callback = function()
+    vim.opt.relativenumber = false
+  end,
+  group = numbertogglegroup,
+  pattern = "*",
 })
 
 -- Open new split panes to right and bottom
@@ -46,8 +109,8 @@ vim.opt.splitright = true
 
 -- Ignore whitespace only changes in diff, always use vertical diffs
 vim.opt.diffopt:append({
-	iwhite,
-	vertical,
-	"linematch:60",
-	algorithm = histogram,
+  iwhite,
+  vertical,
+  "linematch:60",
+  algorithm = histogram,
 })

--- a/vim/lua/config/visual.lua
+++ b/vim/lua/config/visual.lua
@@ -7,7 +7,7 @@ vim.opt.colorcolumn = "+1"
 -- Display extra whitespace
 vim.opt.list = true
 vim.opt.listchars:append({
-	tab = "▏ ",
+	tab = "▏›",
 	leadmultispace = "▏ ",
 	trail = "·",
 	nbsp = "·",

--- a/vim/lua/config/visual.lua
+++ b/vim/lua/config/visual.lua
@@ -8,10 +8,10 @@ vim.opt.colorcolumn = "+1"
 local vert_char = "▏"
 vim.opt.list = true
 vim.opt.listchars:append({
-	tab = vert_char .. "▏›",
-	trail = "·",
-	nbsp = "·",
-	multispace = "·",
+  tab = vert_char .. "▏›",
+  trail = "·",
+  nbsp = "·",
+  multispace = "·",
 })
 
 -- Automatically adapt leadmultispace to current indentation settings, adapted

--- a/vim/lua/plugins/bullets.lua
+++ b/vim/lua/plugins/bullets.lua
@@ -1,3 +1,3 @@
 return {
-	{ "bullets-vim/bullets.vim" },
+  { "bullets-vim/bullets.vim" },
 }

--- a/vim/lua/plugins/csv.lua
+++ b/vim/lua/plugins/csv.lua
@@ -1,3 +1,3 @@
 return {
-	{ "chrisbra/csv.vim" },
+  { "chrisbra/csv.vim" },
 }

--- a/vim/lua/plugins/easy-align.lua
+++ b/vim/lua/plugins/easy-align.lua
@@ -1,11 +1,11 @@
 return {
-	{
-		"junegunn/vim-easy-align",
-		keys = {
-			-- Start interactive EasyAlign in visual mode (e.g. vipga)
-			{ "ga", "<Plug>(EasyAlign)", mode = "x" },
-			-- Start interactive EasyAlign for a motion/text object (e.g. gaip)
-			{ "ga", "<Plug>(EasyAlign)" },
-		},
-	},
+  {
+    "junegunn/vim-easy-align",
+    keys = {
+      -- Start interactive EasyAlign in visual mode (e.g. vipga)
+      { "ga", "<Plug>(EasyAlign)", mode = "x" },
+      -- Start interactive EasyAlign for a motion/text object (e.g. gaip)
+      { "ga", "<Plug>(EasyAlign)" },
+    },
+  },
 }

--- a/vim/lua/plugins/fugitive.lua
+++ b/vim/lua/plugins/fugitive.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-fugitive" },
+  { "tpope/vim-fugitive" },
 }

--- a/vim/lua/plugins/gitsigns.lua
+++ b/vim/lua/plugins/gitsigns.lua
@@ -1,62 +1,62 @@
 return {
-	{
-		"lewis6991/gitsigns.nvim",
-		lazy = false,
-		config = function()
-			require("gitsigns").setup({
-				on_attach = function(bufnr)
-					local gitsigns = require("gitsigns")
+  {
+    "lewis6991/gitsigns.nvim",
+    lazy = false,
+    config = function()
+      require("gitsigns").setup({
+        on_attach = function(bufnr)
+          local gitsigns = require("gitsigns")
 
-					local function map(mode, l, r, opts)
-						opts = opts or {}
-						opts.buffer = bufnr
-						vim.keymap.set(mode, l, r, opts)
-					end
+          local function map(mode, l, r, opts)
+            opts = opts or {}
+            opts.buffer = bufnr
+            vim.keymap.set(mode, l, r, opts)
+          end
 
-					-- Navigation
-					map("n", "]c", function()
-						if vim.wo.diff then
-							vim.cmd.normal({ "]c", bang = true })
-						else
-							gitsigns.nav_hunk("next")
-						end
-					end)
+          -- Navigation
+          map("n", "]c", function()
+            if vim.wo.diff then
+              vim.cmd.normal({ "]c", bang = true })
+            else
+              gitsigns.nav_hunk("next")
+            end
+          end)
 
-					map("n", "[c", function()
-						if vim.wo.diff then
-							vim.cmd.normal({ "[c", bang = true })
-						else
-							gitsigns.nav_hunk("prev")
-						end
-					end)
+          map("n", "[c", function()
+            if vim.wo.diff then
+              vim.cmd.normal({ "[c", bang = true })
+            else
+              gitsigns.nav_hunk("prev")
+            end
+          end)
 
-					-- Actions
-					map("n", "<leader>hs", gitsigns.stage_hunk)
-					map("n", "<leader>hr", gitsigns.reset_hunk)
-					map("v", "<leader>hs", function()
-						gitsigns.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
-					end)
-					map("v", "<leader>hr", function()
-						gitsigns.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
-					end)
-					map("n", "<leader>hS", gitsigns.stage_buffer)
-					map("n", "<leader>hu", gitsigns.undo_stage_hunk)
-					map("n", "<leader>hR", gitsigns.reset_buffer)
-					map("n", "<leader>hp", gitsigns.preview_hunk)
-					map("n", "<leader>hb", function()
-						gitsigns.blame_line({ full = true })
-					end)
-					map("n", "<leader>tb", gitsigns.toggle_current_line_blame)
-					map("n", "<leader>hd", gitsigns.diffthis)
-					map("n", "<leader>hD", function()
-						gitsigns.diffthis("~")
-					end)
-					map("n", "<leader>td", gitsigns.toggle_deleted)
+          -- Actions
+          map("n", "<leader>hs", gitsigns.stage_hunk)
+          map("n", "<leader>hr", gitsigns.reset_hunk)
+          map("v", "<leader>hs", function()
+            gitsigns.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+          end)
+          map("v", "<leader>hr", function()
+            gitsigns.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+          end)
+          map("n", "<leader>hS", gitsigns.stage_buffer)
+          map("n", "<leader>hu", gitsigns.undo_stage_hunk)
+          map("n", "<leader>hR", gitsigns.reset_buffer)
+          map("n", "<leader>hp", gitsigns.preview_hunk)
+          map("n", "<leader>hb", function()
+            gitsigns.blame_line({ full = true })
+          end)
+          map("n", "<leader>tb", gitsigns.toggle_current_line_blame)
+          map("n", "<leader>hd", gitsigns.diffthis)
+          map("n", "<leader>hD", function()
+            gitsigns.diffthis("~")
+          end)
+          map("n", "<leader>td", gitsigns.toggle_deleted)
 
-					-- Text object
-					map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>")
-				end,
-			})
-		end,
-	},
+          -- Text object
+          map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>")
+        end,
+      })
+    end,
+  },
 }

--- a/vim/lua/plugins/gutentags.lua
+++ b/vim/lua/plugins/gutentags.lua
@@ -1,3 +1,3 @@
 return {
-	{ "ludovicchabant/vim-gutentags" },
+  { "ludovicchabant/vim-gutentags" },
 }

--- a/vim/lua/plugins/highlight-colors.lua
+++ b/vim/lua/plugins/highlight-colors.lua
@@ -1,12 +1,12 @@
 return {
-	{
-		"brenoprata10/nvim-highlight-colors",
-		lazy = false,
-		config = function()
-			require("nvim-highlight-colors").setup({
-				render = "virtual",
-				enable_named_colors = false,
-			})
-		end,
-	},
+  {
+    "brenoprata10/nvim-highlight-colors",
+    lazy = false,
+    config = function()
+      require("nvim-highlight-colors").setup({
+        render = "virtual",
+        enable_named_colors = false,
+      })
+    end,
+  },
 }

--- a/vim/lua/plugins/lastplace.lua
+++ b/vim/lua/plugins/lastplace.lua
@@ -1,3 +1,3 @@
 return {
-	{ "farmergreg/vim-lastplace" },
+  { "farmergreg/vim-lastplace" },
 }

--- a/vim/lua/plugins/nvim-solarized-lua.lua
+++ b/vim/lua/plugins/nvim-solarized-lua.lua
@@ -1,10 +1,10 @@
 return {
-	{
-		"ishan9299/nvim-solarized-lua",
-		lazy = false,
-		priority = 1000,
-		config = function()
-			vim.cmd([[ colorscheme solarized ]])
-		end,
-	},
+  {
+    "ishan9299/nvim-solarized-lua",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      vim.cmd([[ colorscheme solarized ]])
+    end,
+  },
 }

--- a/vim/lua/plugins/obsession.lua
+++ b/vim/lua/plugins/obsession.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-obsession" },
+  { "tpope/vim-obsession" },
 }

--- a/vim/lua/plugins/repeat.lua
+++ b/vim/lua/plugins/repeat.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-repeat" },
+  { "tpope/vim-repeat" },
 }

--- a/vim/lua/plugins/rhubarb.lua
+++ b/vim/lua/plugins/rhubarb.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-rhubarb" },
+  { "tpope/vim-rhubarb" },
 }

--- a/vim/lua/plugins/sleuth.lua
+++ b/vim/lua/plugins/sleuth.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-sleuth" },
+  { "tpope/vim-sleuth" },
 }

--- a/vim/lua/plugins/surround.lua
+++ b/vim/lua/plugins/surround.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tpope/vim-surround" },
+  { "tpope/vim-surround" },
 }

--- a/vim/lua/plugins/tcomment.lua
+++ b/vim/lua/plugins/tcomment.lua
@@ -1,3 +1,3 @@
 return {
-	{ "tomtom/tcomment_vim" },
+  { "tomtom/tcomment_vim" },
 }

--- a/vim/lua/plugins/text-objects.lua
+++ b/vim/lua/plugins/text-objects.lua
@@ -1,11 +1,11 @@
 return {
-	{
-		"kana/vim-textobj-user",
-		priority = 100,
-	},
-	{ "kana/vim-textobj-line" },
-	{ "kana/vim-textobj-indent" },
-	{ "kana/vim-textobj-entire" },
-	{ "beloglazov/vim-textobj-quotes" },
-	{ "christoomey/vim-textobj-codeblock" },
+  {
+    "kana/vim-textobj-user",
+    priority = 100,
+  },
+  { "kana/vim-textobj-line" },
+  { "kana/vim-textobj-indent" },
+  { "kana/vim-textobj-entire" },
+  { "beloglazov/vim-textobj-quotes" },
+  { "christoomey/vim-textobj-codeblock" },
 }

--- a/vim/lua/plugins/wordmotion.lua
+++ b/vim/lua/plugins/wordmotion.lua
@@ -1,8 +1,8 @@
 return {
-	{
-		"chaoren/vim-wordmotion",
-		init = function()
-			vim.g.wordmotion_prefix = "<leader>"
-		end,
-	},
+  {
+    "chaoren/vim-wordmotion",
+    init = function()
+      vim.g.wordmotion_prefix = "<leader>"
+    end,
+  },
 }


### PR DESCRIPTION
## What

- Make `lcs-tab` and `lcs-leadmultispace` show different secondary characters to visually differentiate between space- and tab-based indentation.
- Make `lcs-leadmultispace` automatically adapt to `tabstop` and/or `shiftwidth` changes.
- Re-indent all Lua files in `vim/` to use two-space indentation. 

## Why

I wanted two-space indentation in Lua files all along, and I thought I had achieved that using `stylua` but I accidentally made them all use tabs, and I didn't realize because my "visual" Neovim config was set to show leading tabs and leading spaces the same way.

While working on solving this, I realized that the length of `lcs-leadmultispace` needs to match the length of space-based indentation for it to "line up" visually. Since I use a vertical line character to indicate indentation, the `lcs-leadmultispace` value definitely needs to keep up with indentation so that the line will line up, or it will defeat the purpose.

I found and adapted some `autocmd` code that will dynamically change `lcs-leadmultispace` every time either `tabstop` or `shiftwidth` changes, which in turn are kept dynamically in sync with local indentation by `vim-sleuth`.

## Testing

- Confirmed that tab- and space-based indentation is represented differently and easy to tell apart.
- Confirmed all Lua files are now indented with spaces.
- Confirmed `lcs-leadmultispace` correctly follows changes in indentation, resulting in expected "vertical indentation guide line" behavior.