### PR TITLE
fix: Only update lazy.nvim on releases

### DIFF
--- a/vim/lazy-lock.json
+++ b/vim/lazy-lock.json
@@ -2,7 +2,7 @@
   "bullets.vim": { "branch": "master", "commit": "2253f970e54320dbd76fd6bb4f5a0bf2436ce232" },
   "csv.vim": { "branch": "master", "commit": "bddfcbadd788ab11eb3dbba4550a38a412fe3705" },
   "gitsigns.nvim": { "branch": "main", "commit": "4daf7022f1481edf1e8fb9947df13bb07c18e89a" },
-  "lazy.nvim": { "branch": "main", "commit": "b1134ab82ee4279e31f7ddf7e34b2a99eb9b7bc9" },
+  "lazy.nvim": { "branch": "main", "commit": "077102c5bfc578693f12377846d427f49bc50076" },
   "nvim-highlight-colors": { "branch": "main", "commit": "e967e2ba13fd4ca731b41d0e5cc1ac2edcd6e25e" },
   "nvim-solarized-lua": { "branch": "master", "commit": "d69a263c97cbc765ca442d682b3283aefd61d4ac" },
   "tcomment_vim": { "branch": "master", "commit": "48ab639a461d9b8344f7fee06cb69b4374863b13" },

--- a/vim/lua/config/lazy.lua
+++ b/vim/lua/config/lazy.lua
@@ -25,6 +25,8 @@ vim.opt.rtp:prepend(lazypath)
 -- Setup lazy.nvim
 require("lazy").setup({
   spec = {
+    -- Set version for Lazy itself
+    { "folke/lazy.nvim", version = "*" },
     -- import your plugins
     { import = "plugins" },
   },


### PR DESCRIPTION
## What

- Add a short `lazy.nvim` plugin spec with versioning set to follow releases
- Revert Lazy version to latest "stable" release

## Why

Lazy is under rather active development. Which is nice, but I don't want to be updating it and pushing new versions of `lazy-lock.json` all the time...