### PR TITLE
fix: Only run virtualenvwrapper and ruby if they exist

### DIFF
--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -32,5 +32,7 @@ export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
 
 # Ruby gems
-export GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
-export PATH="$PATH:$GEM_HOME/bin"
+if [[ -x $(command -v ruby) ]]; then
+  export GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
+  export PATH="$PATH:$GEM_HOME/bin"
+fi

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -39,7 +39,9 @@ zinit snippet OMZL::key-bindings.zsh
 bindkey '^H' backward-kill-word
 
 # Load virtualenvwrapper
-source /usr/bin/virtualenvwrapper.sh
+if [[ -x /usr/bin/virtualenvwrapper.sh ]]; then
+  source /usr/bin/virtualenvwrapper.sh
+fi
 
 # Don't beep at me, bro!
 setopt nobeep


### PR DESCRIPTION
## What

Adds conditionals to `zshenv` and `zshrc` to check that `ruby` and `python-virtualenvwrapper` are available before trying to invoke them.

# Why

`zshenv` and `zshrc` currently assume that both `ruby` and `python-virtualenvwrapper` are installed, but I don't currently enforce that being the case in `manjaro-packages` so unless/until they get installed, every new shell will complain they don't exist.