### PR TITLE
Fix nvim plugin dependencies

### DIFF
--- a/manjaro_packages
+++ b/manjaro_packages
@@ -1,3 +1,5 @@
+base-devel
+ctags
 neovim
 zsh
 byobu

--- a/manjaro_packages
+++ b/manjaro_packages
@@ -1,8 +1,8 @@
 base-devel
-ctags
-neovim
-zsh
 byobu
+ctags
 fd
 fzf
+neovim
 ripgrep
+zsh


### PR DESCRIPTION
## What

Add `ctags` and `base-devel` to `manjaro_packages`. Also re-order `manjaro-packages` alphabetically.

## Why

Fixes errors thrown by Neovim plugins due to missing dependencies:
- `vim-gutentags` needs `ctags` installed
- Tree-sitter needs C compiling tools