### PR TITLE
Dockerfile optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,18 @@ ENTRYPOINT [ "/usr/bin/bash", "--login" ]
 
 FROM arch-base AS install
 
-# Install pipx, Ansible, and the packages Ansible will install so this step will
-# be cached and not re-run every single docker build. Ansible is super slow to
-# install for some reason, and there's no need to excessively download packages
-# from the Manjaro repo every build...
-COPY manjaro_packages .
+# Install pipx and Ansible so this step will be cached and not re-run every
+# single docker build. Ansible is super slow to install for some reason...
 RUN <<-EOF
   export USE_EMOJI=0 
   sudo pacman -S --needed --noconfirm python-pipx
-  sudo pacman -S --needed --noconfirm - < manjaro_packages
   pipx install --include-deps ansible
 EOF
+
+# Install the packages Ansible will want to install later. There's no need to
+# excessively download packages from the Manjaro repo every build...
+COPY manjaro_packages .
+RUN sudo pacman -S --needed --noconfirm - < manjaro_packages
 
 FROM install AS copy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,12 @@ RUN <<-EOF
   USE_EMOJI=0 ./setup.sh
 EOF
 
+# Run Zsh so Zinit can get set up
+RUN <<-EOF
+  zsh -i -c -- '@zinit-scheduler burst'
+  nvim --headless "+Lazy! restore" +qa
+EOF
+
 # Now that zsh is (or should be) installed, we can make the entrypoint an
 # interactive zsh shell
 ENTRYPOINT [ "/usr/bin/zsh", "--login" ]


### PR DESCRIPTION
## What

- Move Ansible installation into its own earlier Dockerfile layer
- Add Zsh and Neovim plugin initialization commands to Dockerfile

## Why

Ansible is super slow to install, and invalidating the cache on that step every time `manjaro_packages` is changed is a little annoying. Plus, there may be other steps added to that target later which would make the issue worse. Putting it into its own layer that runs as the first step of the `install` target means it should only miss cache (almost) only if the base Arch image has changed.

When doing interactive tests, having to watch the Zsh and Neovim plugins get installed is annoying. Plus, I'd like these to be part of the build since that's all the CI I'm currently running.