### PR TITLE
feat: add keymaps for opening quickfix list and floating window

### DIFF
--- a/vim/lua/config/remaps.lua
+++ b/vim/lua/config/remaps.lua
@@ -7,3 +7,17 @@ vim.keymap.set("i", "<A-k>", "<Esc>:m .-2<CR>==gi")
 -- and in visual mode
 vim.keymap.set("v", "<A-j>", ":m '>+1<CR>gv=gv")
 vim.keymap.set("v", "<A-k>", ":m '<-2<CR>gv=gv")
+
+-- Diagnostic keymaps
+vim.keymap.set(
+  "n",
+  "<leader>q",
+  vim.diagnostic.setloclist,
+  { desc = "Open diagnostic [q]uickfix list" }
+)
+vim.keymap.set(
+  "n",
+  "<leader>Q",
+  vim.diagnostic.open_float,
+  { desc = "Open diagnostic [Q]uickfix floating window" }
+)


### PR DESCRIPTION
What
---
Adds `<leader>q` and `<leader>Q` to open the quickfix list and floating window, respectively.

Why
---
Inline diagnostic messages are nice and all, but they often go past the edge of my terminal where I can't read them... It's nice to be able to see the full list and jump to different things from there anyway.